### PR TITLE
Updated README.md: code examples for outline colorboxes now use correct function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Current features include:
 ]
 ```
 
-## Outlinebox
+## Outline Colorbox
 
 ![outlinebox_example](examples/outline-colorbox.png)
 
 ### Usage
 
 ```
-#outlinebox(
+#outline-colorbox(
   title: lorem(5),
   width: auto,
   radius: 2pt,
@@ -61,7 +61,7 @@ Current features include:
   #lorem(50)
 ]
 
-#outlinebox(
+#outline-colorbox(
   title: lorem(5),
   color: "green",
   width: auto,


### PR DESCRIPTION
Thank you for the useful package!

I tried out the examples from the [typst universe page](https://typst.app/universe/package/colorful-boxes/) (as of version 1.3.1) and got an _**unresolved import**_ error for `outlinebox`.

This PR should fix this.


