### PR TITLE
feat: Color boxes can now be made breakable

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -11,6 +11,7 @@
   color: "default",
   radius: 2pt,
   width: auto,
+  breakable: true,
   body,
 ) = {
   return block(
@@ -18,6 +19,7 @@
     stroke: 2pt + box-colors.at(color).stroke,
     radius: radius,
     width: width,
+    breakable: breakable,
   )[
     #if title != none [
       #block(


### PR DESCRIPTION
Color boxes can now be set to break to new page if too large, or if the box should just split. This has been done using the `breakable` property of `#block`. 