### PR TITLE
Allow color definition in `slanted-colorbox`

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -142,6 +142,7 @@
 
 #let slanted-colorbox(
   title: "Title",
+  box-colors: box-colors,
   color: "default",
   radius: 2pt,
   stroke: 2pt,

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colorful-boxes"
-version = "1.4.1"
+version = "1.4.2"
 repository = "https://github.com/lkoehl/typst-boxes"
 entrypoint = "lib.typ"
 exclude = ["/examples/*"]


### PR DESCRIPTION
The possibility of customizing color definitions (`box-colors`) was first requested in #17 and implemented in 58f177b. However, `slanted-colorbox` was forgotten.